### PR TITLE
Implement search + play functionality

### DIFF
--- a/backend/app/api/api_v1/routers/spotify.py
+++ b/backend/app/api/api_v1/routers/spotify.py
@@ -34,8 +34,7 @@ async def logout(request: Request):
     return clear_token()
 
 @r.post("/search",
-        response_model=SpotifySearchResponse,
-        response_model_exclude_none=True)
+        response_model=SpotifySearchResponse)
 async def search(request: Request,
                  payload: SpotifySearchRequest):
     """
@@ -49,3 +48,4 @@ async def token(request: Request):
     Fetch token for Spotify client persisted to cache.
     """
     return get_token()
+

--- a/backend/app/api/api_v1/routers/spotify.py
+++ b/backend/app/api/api_v1/routers/spotify.py
@@ -1,7 +1,14 @@
 import requests
 import typing as t
 
-from app.core.spotify import get_token, get_url, clear_token, set_token
+from app.core.spotify import (
+    clear_token,
+    get_token,
+    get_url,
+    search_library,
+    set_token
+)
+from app.db.schemas import SpotifySearchRequest, SpotifySearchResponse
 from fastapi import APIRouter, Request, Depends, Response, encoders
 from fastapi.responses import HTMLResponse
 from starlette.responses import RedirectResponse
@@ -25,6 +32,16 @@ async def logout(request: Request):
     Logout of Spotify client.
     """
     return clear_token()
+
+@r.post("/search",
+        response_model=SpotifySearchResponse,
+        response_model_exclude_none=True)
+async def search(request: Request,
+                 payload: SpotifySearchRequest):
+    """
+    Search Spotify library.
+    """
+    return search_library(payload)
 
 @r.post("/token")
 async def token(request: Request):

--- a/backend/app/api/api_v1/routers/spotify.py
+++ b/backend/app/api/api_v1/routers/spotify.py
@@ -20,10 +20,10 @@ async def login(request: Request):
     return {"url": get_url()}
 
 @r.get("/logout")
+async def logout(request: Request):
     """
     Logout of Spotify client.
     """
-async def logout(request: Request):
     return clear_token()
 
 @r.post("/token")

--- a/backend/app/core/spotify.py
+++ b/backend/app/core/spotify.py
@@ -1,6 +1,18 @@
+import json
 import os
 import spotipy
 
+from app.db.schemas import (
+    SpotifyMusicAlbum,
+    SpotifyMusicArtist,
+    SpotifyMusicSearchResult,
+    SpotifyMusicSearchResults,
+    SpotifyMusicSong,
+    SpotifyPodcastEpisode,
+    SpotifyPodcastSearchResult,
+    SpotifyPodcastSearchResults,
+    SpotifySearchResponse
+)
 from spotipy.oauth2 import SpotifyOAuth
 
 AUTH_ENDPOINT = "https://accounts.spotify.com/authorize"
@@ -23,6 +35,57 @@ auth_manager = SpotifyOAuth(
     redirect_uri=REDIRECT_URI,
     scope=" ".join(SCOPES))
 
+def _music_item_to_schema(req):
+    return SpotifyMusicSearchResult(
+        album=SpotifyMusicAlbum(
+            id=req["album"]["id"],
+            image_url=req["album"]["images"][0]["url"] \
+                      if len(req["album"]["images"]) > 0 else None,
+            name=req["album"]["name"],
+            uri=req["album"]["uri"]
+        ),
+        artists=[SpotifyMusicArtist(
+            id=i["id"],
+            name=i["name"],
+            uri=i["uri"]
+        ) for i in req["artists"]],
+        song=SpotifyMusicSong(
+            duration=req["duration_ms"],
+            id=req["id"],
+            name=req["name"],
+            uri=req["uri"]
+        )
+    )
+
+def _music_to_schema(req):
+    return SpotifyMusicSearchResults(
+        items=[_music_item_to_schema(i) for i in req["items"]],
+        paged_url=req["href"]
+    )
+
+def _podcast_item_to_schema(req):
+    return SpotifyPodcastSearchResult(
+        episode=SpotifyPodcastEpisode(
+            duration=req["duration_ms"],
+            id=req["id"],
+            image_url=req["images"][0]["url"] if len(req["images"]) > 0 else None,
+            name=req["name"],
+            uri=req["uri"]
+        )
+    )
+
+def _podcast_to_schema(req):
+    return SpotifyPodcastSearchResults(
+        items=[_podcast_item_to_schema(i) for i in req["items"]],
+        paged_url=req["href"]
+    )
+
+def _response_to_schema(req):
+    return SpotifySearchResponse(
+        music=_music_to_schema(req["tracks"]),
+        podcasts=_podcast_to_schema(req["episodes"])
+    )
+
 def clear_token():
     try:
         os.remove(CACHE)
@@ -42,6 +105,11 @@ def get_token():
         "url": auth_manager.get_authorize_url(),
         "status": "must first authorize via URL before tokens can be granted"
     }
+
+def search_library(payload):
+    s = spotipy.Spotify(auth_manager.get_cached_token()["access_token"])
+    res = s.search(payload.query, type=",".join(payload.content_type))
+    return _response_to_schema(res)
 
 def set_token(token):
     auth_info = auth_manager.get_access_token(token)

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -9,10 +9,8 @@ class UserBase(BaseModel):
     first_name: str = None
     last_name: str = None
 
-
 class UserOut(UserBase):
     pass
-
 
 class UserCreate(UserBase):
     password: str
@@ -20,13 +18,11 @@ class UserCreate(UserBase):
     class Config:
         orm_mode = True
 
-
 class UserEdit(UserBase):
     password: t.Optional[str] = None
 
     class Config:
         orm_mode = True
-
 
 class User(UserBase):
     id: int
@@ -34,12 +30,65 @@ class User(UserBase):
     class Config:
         orm_mode = True
 
-
 class Token(BaseModel):
     access_token: str
     token_type: str
 
-
 class TokenData(BaseModel):
     email: str = None
     permissions: str = "user"
+
+# MUSIC
+
+class SpotifyMusicArtist(BaseModel):
+    id: str
+    name: str
+    uri: str
+
+class SpotifyMusicAlbum(BaseModel):
+    id: str
+    image_url: str
+    name: str
+    uri: str
+
+class SpotifyMusicSong(BaseModel):
+    duration: int
+    id: str
+    name: str
+    uri: str
+
+# PODCASTS
+
+class SpotifyPodcastEpisode(BaseModel):
+    duration: int
+    id: str
+    image_url: str
+    name: str
+    uri: str
+
+# SPOTIFY SEARCH
+
+class SpotifyPodcastSearchResult(BaseModel):
+    episode: SpotifyPodcastEpisode
+
+class SpotifyPodcastSearchResults(BaseModel):
+    items: t.List[SpotifyPodcastSearchResult]
+    paged_url: str
+
+class SpotifyMusicSearchResult(BaseModel):
+    album: SpotifyMusicAlbum
+    artists: t.List[SpotifyMusicArtist]
+    song: SpotifyMusicSong
+
+class SpotifyMusicSearchResults(BaseModel):
+    items: t.List[SpotifyMusicSearchResult]
+    paged_url: str
+
+class SpotifySearchRequest(BaseModel):
+    query: str = None
+    content_type: str = ["episode", "track"]
+
+class SpotifySearchResponse(BaseModel):
+    music: SpotifyMusicSearchResults
+    podcasts: SpotifyPodcastSearchResults
+

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -73,7 +73,7 @@ class SpotifyPodcastSearchResult(BaseModel):
 
 class SpotifyPodcastSearchResults(BaseModel):
     items: t.List[SpotifyPodcastSearchResult]
-    paged_url: str
+    paged_url: t.Optional[str] = None
 
 class SpotifyMusicSearchResult(BaseModel):
     album: SpotifyMusicAlbum
@@ -82,11 +82,11 @@ class SpotifyMusicSearchResult(BaseModel):
 
 class SpotifyMusicSearchResults(BaseModel):
     items: t.List[SpotifyMusicSearchResult]
-    paged_url: str
+    paged_url: t.Optional[str] = None
 
 class SpotifySearchRequest(BaseModel):
     query: str = None
-    content_type: str = ["episode", "track"]
+    content_type: str = ["track"]
 
 class SpotifySearchResponse(BaseModel):
     music: SpotifyMusicSearchResults

--- a/frontend/src/views/Player.tsx
+++ b/frontend/src/views/Player.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react';
 import SpotifyPlayer from "react-spotify-web-playback";
+import { makeStyles } from '@material-ui/core/styles';
 
 interface Props {
 }
@@ -11,7 +12,68 @@ interface Item {
   duration_ms: number
 }
 
+interface MusicAlbumResult {
+  id: string,
+  image_url: string,
+  name: string,
+  uri: string
+}
+
+interface MusicArtistResult {
+  id: string,
+  name: string,
+  uri: string
+}
+
+interface MusicSongResult {
+  duration: number,
+  id: string,
+  name: string,
+  uri: string
+}
+
+interface MusicResult {
+  album: MusicAlbumResult,
+  artists: MusicArtistResult[],
+  song: MusicSongResult
+}
+
+interface MusicResults {
+  items: MusicResult[],
+  paged_url: string
+}
+
+interface PodcastEpisodeResult {
+  duration: number,
+  id: string,
+  image_url: string,
+  name: string,
+  uri: string
+}
+
+interface PodcastResult {
+  episode: PodcastEpisodeResult
+}
+
+interface PodcastResults {
+  items: PodcastResult[],
+  paged_url: string
+}
+
+interface Results {
+  music: MusicResults,
+  podcasts: PodcastResults,
+}
+
+const useStyles = makeStyles((theme) => ({
+  link: {
+    color: '#61dafb',
+    cursor: 'pointer'
+  },
+}));
+
 export const Player: FC = () => {
+  const classes = useStyles();
   const [isPlaying, setIsPlaying] = useState<string>('Paused');
   const [progressMs, setProgressMs] = useState<number>(0);
   const [item, setItem] = useState<Item>({
@@ -24,6 +86,17 @@ export const Player: FC = () => {
   });
   const [noData, setNoData] = useState<boolean>(true);
   const [token, setToken] = useState<string | undefined>(undefined);
+  const [results, setResults] = useState<Results>({
+    music: {
+      items: [],
+      paged_url: ""
+    },
+    podcasts: {
+      items: [],
+      paged_url: ""
+    }
+  });
+  const [track, setTrack] = useState<string>("spotify:artist:6HQYnRM4OzToCYPpVBInuU");
 
   const getCurrentlyPlaying = (token: string) => {
     // Make a call using the token
@@ -86,6 +159,25 @@ export const Player: FC = () => {
     setToken(undefined);
   };
 
+  const searchSpotify = async(query: string) => {
+    const request = new Request('/api/spotify/search', {
+      body: JSON.stringify({query: query}),
+      headers: {'Content-Type': 'application/json'},
+      method: 'POST'
+    });
+    return fetch(request)
+      .then((response) => {
+        if (response.status < 200 || response.status >= 300) {
+          throw new Error(response.statusText);
+        }
+        return response.json();
+      })
+      .then((data) => {
+        console.log(data);
+        setResults(data);
+      });
+  }
+
   const getSpotifyToken = async () => {
     const request = new Request('/api/spotify/token', {
       method: 'POST'
@@ -118,9 +210,27 @@ export const Player: FC = () => {
           </button>
         )}
         {token && [
+          <input
+            key="search"
+            onChange={event => searchSpotify(event.target.value)}
+          />,
+          results.music.items.map(i =>
+            <div className={classes.link}
+                 key={`${i.song.id}`}
+                 onClick={_ => setTrack(i.song.uri)}>
+              <span>{i.artists.map(j => j.name).join(", ")} - </span>
+              <span>{i.song.name}</span>
+            </div>
+          ),
+          results.podcasts.items.map(i =>
+            <div className={classes.link}
+                 key={`${i.episode.id}`}>
+              <span>{i.episode.name}</span>
+            </div>
+          ),
           <SpotifyPlayer
             token={token}
-            uris={["spotify:artist:6HQYnRM4OzToCYPpVBInuU"]}
+            uris={[track]}
             key="player"
           />,
           <button className="btn"
@@ -131,11 +241,6 @@ export const Player: FC = () => {
         ]}
         {token && !noData && (
           <p>Currently playing: {item.name}</p>
-        )}
-        {token && noData && (
-          <p>
-            You need to be playing a song on Spotify for something to appear here.
-          </p>
         )}
       </header>
     </div>

--- a/frontend/src/views/Player.tsx
+++ b/frontend/src/views/Player.tsx
@@ -100,13 +100,13 @@ export const Player: FC = () => {
     }
   };
 
-  const tick = () => {
-    if(token) {
-      getCurrentlyPlaying(token);
-    }
-  }
+  // const tick = () => {
+  //   if(token) {
+  //     getCurrentlyPlaying(token);
+  //   }
+  // }
   getSpotifyToken();
-  setInterval(() => tick(), 5000);
+  // setInterval(() => tick(), 5000);
 
   return (
     <div className="App">


### PR DESCRIPTION
Implements an `api/spotify/search` `POST` API around [`Spotipy`'s `search` method](https://spotipy.readthedocs.io/en/2.19.0/#spotipy.client.Spotify.search) to be consumed by the client so the user can query for a specific track and then play it in the [`SpotifyPlayer` component](https://github.com/adityaviswanathan/spotifork/blob/7e080604cdcd0dc1973f96d0e09f973f5a833bd2/frontend/src/views/Player.tsx#L123).

- [x] Wire up a `POST` `api/spotify/search` API that consumes _both_ the Spotify [music](https://developer.spotify.com/documentation/web-api/reference/#category-tracks) and [podcast](https://developer.spotify.com/documentation/web-api/reference/#category-episodes) libraries
- [x] Implement `pydantic` schemas to support trimmed responses containing only the fields necessary for the client (e.g. Spotify URI)
- [ ] Add search bar component to client that consumes `POST` `api/spotify/search` to fetch search results and display in a list
- [ ] When the user selects an item in the list, pass the selected (music) track or (podcast) episode via Spotify URI into [`SpotifyPlayer`'s `uris`](https://github.com/adityaviswanathan/spotifork/blob/7e080604cdcd0dc1973f96d0e09f973f5a833bd2/frontend/src/views/Player.tsx#L123) property so it can be played